### PR TITLE
Improve hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
     }
   ],
   "require": {
-    "proteusthemes/wp-content-importer-v2": "^2.0.0"
+    "proteusthemes/wp-content-importer-v2": "^2.0.1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
     }
   ],
   "require": {
-    "proteusthemes/wp-content-importer-v2": "^2.0.1"
+    "proteusthemes/wp-content-importer-v2": "^2.0.2"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "04c02f4b81416890a939f2bdc24450d3",
+    "content-hash": "2db0fd87f325055e5079237a39357143",
     "packages": [
         {
             "name": "proteusthemes/wp-content-importer-v2",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/proteusthemes/WordPress-Importer.git",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2db0fd87f325055e5079237a39357143",
+    "content-hash": "f714d039650595df06c8e06490894234",
     "packages": [
         {
             "name": "proteusthemes/wp-content-importer-v2",
-            "version": "v2.0.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/proteusthemes/WordPress-Importer.git",
-                "reference": "58cdc8406d74f3d9740649356ecb1302b06e9544"
+                "reference": "704d3900b189ef58733e7eab75becd370d47ef9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/proteusthemes/WordPress-Importer/zipball/58cdc8406d74f3d9740649356ecb1302b06e9544",
-                "reference": "58cdc8406d74f3d9740649356ecb1302b06e9544",
+                "url": "https://api.github.com/repos/proteusthemes/WordPress-Importer/zipball/704d3900b189ef58733e7eab75becd370d47ef9e",
+                "reference": "704d3900b189ef58733e7eab75becd370d47ef9e",
                 "shasum": ""
             },
             "type": "library",
@@ -45,9 +45,9 @@
                 "wp"
             ],
             "support": {
-                "source": "https://github.com/proteusthemes/WordPress-Importer/tree/v2.0.0"
+                "source": "https://github.com/proteusthemes/WordPress-Importer/tree/v2.0.2"
             },
-            "time": "2018-02-07T12:55:25+00:00"
+            "time": "2018-02-09T08:14:54+00:00"
         }
     ],
     "packages-dev": [],

--- a/includes/class-merlin-customizer-importer.php
+++ b/includes/class-merlin-customizer-importer.php
@@ -82,7 +82,7 @@ class Merlin_Customizer_Importer {
 		}
 
 		// Import images.
-		if ( apply_filters( 'pt-ocdi/customizer_import_images', true ) ) {
+		if ( apply_filters( 'merlin_customizer_import_images', true ) ) {
 			$data['mods'] = self::import_customizer_images( $data['mods'] );
 		}
 
@@ -105,7 +105,7 @@ class Merlin_Customizer_Importer {
 		}
 
 		// Should the customizer import use the WP customize_save* hooks?
-		$use_wp_customize_save_hooks = apply_filters( 'pt-ocdi/enable_wp_customize_save_hooks', false );
+		$use_wp_customize_save_hooks = apply_filters( 'merlin_enable_wp_customize_save_hooks', false );
 
 		if ( $use_wp_customize_save_hooks ) {
 			do_action( 'customize_save', $wp_customize );

--- a/includes/class-merlin-hooks.php
+++ b/includes/class-merlin-hooks.php
@@ -16,6 +16,7 @@ class Merlin_Hooks {
 	 */
 	public function __construct() {
 		add_action( 'merlin_widget_settings_array', array( $this, 'fix_custom_menu_widget_ids' ) );
+		add_action( 'import_start', array( $this, 'maybe_disable_creating_different_size_images_during_import' ) );
 	}
 
 	/**
@@ -53,5 +54,14 @@ class Merlin_Hooks {
 		do_action( 'merlin_after_all_import', $selected_import_index );
 
 		return true;
+	}
+
+	/**
+	 * Maybe disables generation of multiple image sizes (thumbnails) in the content import step.
+	 */
+	public function maybe_disable_creating_different_size_images_during_import() {
+		if ( ! apply_filters( 'merlin_regenerate_thumbnails_in_content_import', true ) ) {
+			add_filter( 'intermediate_image_sizes_advanced', '__return_null' );
+		}
 	}
 }

--- a/includes/class-merlin-hooks.php
+++ b/includes/class-merlin-hooks.php
@@ -43,4 +43,15 @@ class Merlin_Hooks {
 
 		return $widget;
 	}
+
+	/**
+	 * Wrapper function for the after all import action hook.
+	 *
+	 * @param int $selected_import_index The selected demo import index.
+	 */
+	public function after_all_import_action( $selected_import_index ) {
+		do_action( 'merlin_after_all_import', $selected_import_index );
+
+		return true;
+	}
 }

--- a/includes/class-merlin-hooks.php
+++ b/includes/class-merlin-hooks.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class for the custom WP hooks.
+ *
+ * @package Merlin WP
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Merlin_Hooks {
+	/**
+	 * The class constructor.
+	 */
+	public function __construct() {
+		add_action( 'merlin_widget_settings_array', array( $this, 'fix_custom_menu_widget_ids' ) );
+	}
+
+	/**
+	 * Change the menu IDs in the custom menu widgets in the widget import data.
+	 * This solves the issue with custom menu widgets not having the correct (new) menu ID, because they
+	 * have the old menu ID from the export site.
+	 *
+	 * @param array $widget The widget settings array.
+	 */
+	public function fix_custom_menu_widget_ids( $widget ) {
+		// Skip (no changes needed), if this is not a custom menu widget.
+		if ( ! array_key_exists( 'nav_menu', $widget ) || empty( $widget['nav_menu'] ) || ! is_int( $widget['nav_menu'] ) ) {
+			return $widget;
+		}
+
+		// Get import data, with new menu IDs.
+		$importer = new ProteusThemes\WPContentImporter2\Importer( array( 'fetch_attachments' => true ), new ProteusThemes\WPContentImporter2\WPImporterLogger() );
+		$importer->restore_import_data_transient();
+
+		$importer_mapping = $importer->get_mapping();
+		$term_ids         = empty( $importer_mapping['term_id'] ) ? array() : $importer_mapping['term_id'];
+
+		// Set the new menu ID for the widget.
+		$widget['nav_menu'] = empty( $term_ids[ $widget['nav_menu'] ] ) ? $widget['nav_menu'] : $term_ids[ $widget['nav_menu'] ];
+
+		return $widget;
+	}
+}

--- a/includes/class-merlin-widget-importer.php
+++ b/includes/class-merlin-widget-importer.php
@@ -96,8 +96,8 @@ class Merlin_Widget_Importer {
 		}
 
 		// Hook before import.
-		do_action( 'pt-ocdi/widget_importer_before_widgets_import' );
-		$data = apply_filters( 'pt-ocdi/before_widgets_import_data', $data );
+		do_action( 'merlin_widget_importer_before_widgets_import' );
+		$data = apply_filters( 'merlin_before_widgets_import_data', $data );
 
 		// Get all available widgets site supports.
 		$available_widgets = self::available_widgets();
@@ -157,7 +157,7 @@ class Merlin_Widget_Importer {
 				// Filter to modify settings object before conversion to array and import.
 				// Leave this filter here for backwards compatibility with manipulating objects (before conversion to array below).
 				// Ideally the newer wie_widget_settings_array below will be used instead of this.
-				$widget = apply_filters( 'pt-ocdi/widget_settings', $widget ); // Object.
+				$widget = apply_filters( 'merlin_widget_settings', $widget ); // Object.
 
 				// Convert multidimensional objects to multidimensional arrays.
 				// Some plugins like Jetpack Widget Visibility store settings as multidimensional arrays.
@@ -169,7 +169,7 @@ class Merlin_Widget_Importer {
 				// Filter to modify settings array.
 				// This is preferred over the older wie_widget_settings filter above.
 				// Do before identical check because changes may make it identical to end result (such as URL replacements).
-				$widget = apply_filters( 'pt-ocdi/widget_settings_array', $widget );
+				$widget = apply_filters( 'merlin_widget_settings_array', $widget );
 
 				// Does widget with identical settings already exist in same sidebar?
 				if ( ! $fail && isset( $widget_instances[ $id_base ] ) ) {
@@ -237,7 +237,7 @@ class Merlin_Widget_Importer {
 						'widget_id_num'     => $new_instance_id_number,
 						'widget_id_num_old' => $instance_id_number,
 					);
-					do_action( 'pt-ocdi/widget_importer_after_single_widget_import', $after_widget_import );
+					do_action( 'merlin_widget_importer_after_single_widget_import', $after_widget_import );
 
 					// Success message.
 					if ( $sidebar_available ) {
@@ -260,10 +260,10 @@ class Merlin_Widget_Importer {
 		}
 
 		// Hook after import.
-		do_action( 'pt-ocdi/widget_importer_after_widgets_import' );
+		do_action( 'merlin_widget_importer_after_widgets_import' );
 
 		// Return results.
-		return apply_filters( 'pt-ocdi/widget_import_results', $results );
+		return apply_filters( 'merlin_widget_import_results', $results );
 	}
 
 
@@ -288,7 +288,7 @@ class Merlin_Widget_Importer {
 			}
 		}
 
-		return apply_filters( 'pt-ocdi/available_widgets', $available_widgets );
+		return apply_filters( 'merlin_available_widgets', $available_widgets );
 	}
 
 

--- a/merlin.php
+++ b/merlin.php
@@ -234,6 +234,10 @@ class Merlin {
 		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-customizer-option.php' );
 		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-customizer-importer.php' );
 
+		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-hooks.php' );
+
+		$hooks = new Merlin_Hooks();
+
 		if ( class_exists( 'EDD_Theme_Updater_Admin' ) ) {
 			$this->updater = new EDD_Theme_Updater_Admin();
 		}

--- a/merlin.php
+++ b/merlin.php
@@ -59,6 +59,13 @@ class Merlin {
 	protected $importer;
 
 	/**
+	 * WP Hook class.
+	 *
+	 * @var Merlin_Hooks
+	 */
+	protected $hooks;
+
+	/**
 	 * Helper.
 	 *
 	 * @var    array
@@ -236,7 +243,7 @@ class Merlin {
 
 		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-hooks.php' );
 
-		$hooks = new Merlin_Hooks();
+		$this->hooks = new Merlin_Hooks();
 
 		if ( class_exists( 'EDD_Theme_Updater_Admin' ) ) {
 			$this->updater = new EDD_Theme_Updater_Admin();
@@ -1455,6 +1462,19 @@ class Merlin {
 				'install_callback' => array( 'Merlin_Customizer_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $base_dir . 'customizer.dat',
+			);
+		}
+
+		if ( false !== has_action( 'merlin_after_all_import' ) ) {
+			$content['after_import'] = array(
+				'title'            => esc_html__( 'After import setup', '@@textdomain' ),
+				'description'      => esc_html__( 'After import setup.', '@@textdomain' ),
+				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
+				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
+				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'install_callback' => array( $this->hooks, 'after_all_import_action' ),
+				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
+				'data'             => 0,
 			);
 		}
 


### PR DESCRIPTION
This PR is all about custom hooks.

We added/replaced a few custom hooks, so that the WP Merlin will have more flexibility:
- after all import hook, which also displays as a step in the importer (if the hook is being used),
- the custom menu widget import fix 
- utility hook for disabling smaller image generation during content import

