### PR TITLE
Add demo import select

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ function merlin_local_import_files() {
 add_filter( 'merlin_import_files', 'merlin_local_import_files' );
 ```
 
+#### Multiple demo imports?
+If you have multiple demo imports, then just define multiple arrays with appropriate data. For an example of two predefined demo imports, please look at the ` merlin-filters.php` file.
+
 ### 4. Add filters
 
 Inside the package download exists a `merlin-filters.php` file which includes examples of the different filters you may use to modify Merlin. A primary example would be to use to `merlin_generate_child_functions_php` filter to modify the contents of the generated child theme's `functions.php` file. 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ If you have TGMPA included within your theme, please ensure Merlin WP is include
 
 ### 2. Configure Merlin WP
 
-The `merlin-config.php` file tells Merlin WP where the class is installed and where your demo content is located. It also let's you modify any of the text strings throughout the wizard.
+The `merlin-config.php` file tells Merlin WP where the class is installed. It also let's you modify any of the text strings throughout the wizard.
 
 ** The important configuration settings: **
 * `directory` — The location in your theme where the `/merlin/` directory is placed
-* `demo_directory` — The directory location of where your demo content is located
 
 Other settings:
 * `merlin_url` — The admin url where Merlin WP will exist

--- a/README.md
+++ b/README.md
@@ -44,14 +44,54 @@ Other settings:
 * `dev_mode` — Retain the "Theme Setup" menu item under the WordPress Admin > Appearance section for testing. Also enables JS/CSS minified files. This is on by default during the beta.
 * `branding` — Show Merlin WP's logo or not *(beta)*
 
-### 3. Add your demo content
+### 3. Define your demo content import files
 
-Add your theme's demo content to the demo directory location specificed in the `merlin-config.php` file.
-
-You'll want to add the following files:
+You'll need the following files:
 * `content.xml` — Exported demo content using the WordPress Exporter
 * `widgets.wie` — Exported widgets using [Widget Importer & Exporter](https://wordpress.org/plugins/widget-importer-exporter/)
 * `customizer.dat` — Exported Customizer settings using [Customizer Export/Import](https://wordpress.org/plugins/customizer-export-import/)
+
+Once you have those files, you can upload them to your server (recommeded), or include them somewhere in your theme.
+
+Next you have to define a filter in your theme, to let WP Merlin know, where these files are located. Depending on where you placed the import files, you have two ways to define the filter:
+
+1\. If you uploaded the import files to your server, then use this code example and edit it, to suit your file locations:
+
+```
+function merlin_import_files() {
+	return array(
+		array(
+			'import_file_name'           => 'Demo Import 1',
+			'import_file_url'            => 'http://www.your_domain.com/merlin/demo-content.xml',
+			'import_widget_file_url'     => 'http://www.your_domain.com/merlin/widgets.json',
+			'import_customizer_file_url' => 'http://www.your_domain.com/merlin/customizer.dat',
+			'import_preview_image_url'   => 'http://www.your_domain.com/merlin/preview_import_image1.jpg',
+			'import_notice'              => __( 'A special note for this import.', 'your-textdomain' ),
+			'preview_url'                => 'http://www.your_domain.com/my-demo-1',
+		),
+	);
+}
+add_filter( 'merlin_import_files', 'merlin_import_files' );
+```
+
+2\. If you included the import files somewhere in the theme, then use this code example:
+
+```
+function merlin_local_import_files() {
+	return array(
+		array(
+			'import_file_name'             => 'Demo Import 1',
+			'local_import_file'            => trailingslashit( get_template_directory() ) . 'merlin/demo-content.xml',
+			'local_import_widget_file'     => trailingslashit( get_template_directory() ) . 'merlin/widgets.json',
+			'local_import_customizer_file' => trailingslashit( get_template_directory() ) . 'merlin/customizer.dat',
+			'import_preview_image_url'     => 'http://www.your_domain.com/merlin/preview_import_image1.jpg',
+			'import_notice'                => __( 'After you import this demo, you will have to setup the slider separately.', 'your-textdomain' ),
+			'preview_url'                  => 'http://www.your_domain.com/my-demo-1',
+		),
+	);
+}
+add_filter( 'merlin_import_files', 'merlin_local_import_files' );
+```
 
 ### 4. Add filters
 

--- a/assets/js/merlin.js
+++ b/assets/js/merlin.js
@@ -83,6 +83,28 @@ var Merlin = (function($){
                 return true;
             }
         });
+
+				$( document ).on( 'change', '.js-merlin-demo-import-select', function() {
+					var selectedIndex  = $( this ).val(),
+						$selectedOption  = $( this ).children( ':selected' ),
+						optionImgSrc     = $selectedOption.data( 'img-src' ),
+						optionNotice     = $selectedOption.data( 'notice' ),
+						optionPreviewUrl = $selectedOption.data( 'preview-url' );
+
+					$.post( merlin_params.ajaxurl, {
+						action: 'merlin_update_selected_import_data_info',
+						wpnonce: merlin_params.wpnonce,
+						selected_index: selectedIndex,
+					}, function( response ) {
+						if ( response.success ) {
+							$( '.js-merlin-drawer-import-content' ).html( response.data );
+						}
+						else {
+							alert( merlin_params.texts.something_went_wrong );
+						}
+					} )
+						.fail( function() { alert( merlin_params.texts.something_went_wrong ) } );
+				} );
     }
 
     function ChildTheme() {

--- a/assets/js/merlin.js
+++ b/assets/js/merlin.js
@@ -422,6 +422,12 @@ var Merlin = (function($){
                 $(".merlin__drawer--import-content").find("input").prop("disabled", true);
                 complete = function(){
 
+									$.post(merlin_params.ajaxurl, {
+										action: "merlin_import_finished",
+										wpnonce: merlin_params.wpnonce,
+										selected_index: $( '.js-merlin-demo-import-select' ).val() || 0
+									});
+
                 	setTimeout(function(){
 				       body.removeClass( drawer_opened );
 				    },500);

--- a/assets/js/merlin.js
+++ b/assets/js/merlin.js
@@ -380,7 +380,8 @@ var Merlin = (function($){
                     jQuery.post(merlin_params.ajaxurl, {
                         action: "merlin_content",
                         wpnonce: merlin_params.wpnonce,
-                        content: current_item
+                        content: current_item,
+                        selected_index: $( '.js-merlin-demo-import-select' ).val() || 0
                     }, ajax_callback).fail(ajax_callback);
                 }else{
                     $current_node.addClass("skipping");

--- a/includes/class-merlin-downloader.php
+++ b/includes/class-merlin-downloader.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Class for downloading a file from a given URL.
+ *
+ * @package Merlin WP
+ */
+
+class Merlin_Downloader {
+	/**
+	 * Holds full path to where the files will be saved.
+	 *
+	 * @var string
+	 */
+	private $download_directory_path = '';
+
+	/**
+	 * Constructor method.
+	 *
+	 * @param string $download_directory_path Full path to where the files will be saved.
+	 */
+	public function __construct( $download_directory_path = '' ) {
+		$this->set_download_directory_path( $download_directory_path );
+	}
+
+
+	/**
+	 * Download file from a given URL.
+	 *
+	 * @param string $url URL of file to download.
+	 * @param string $filename Filename of the file to save.
+	 * @return string|WP_Error Full path to the downloaded file or WP_Error object with error message.
+	 */
+	public function download_file( $url, $filename ) {
+		$content = $this->get_content_from_url( $url );
+
+		// Check if there was an error and break out.
+		if ( is_wp_error( $content ) ) {
+			return $content;
+		}
+
+		$saved_file = file_put_contents( $this->download_directory_path . $filename, $content );
+
+		if ( ! empty( $saved_file ) ) {
+			return $this->download_directory_path . $filename;
+		}
+
+		return false;
+	}
+
+
+	/**
+	 * Helper function: get content from an URL.
+	 *
+	 * @param string $url URL to the content file.
+	 * @return string|WP_Error, content from the URL or WP_Error object with error message.
+	 */
+	private function get_content_from_url( $url ) {
+		// Test if the URL to the file is defined.
+		if ( empty( $url ) ) {
+			return new \WP_Error(
+				'missing_url',
+				__( 'Missing URL for downloading a file!', 'pt-ocdi' )
+			);
+		}
+
+		// Get file content from the server.
+		$response = wp_remote_get(
+			$url,
+			array( 'timeout' => apply_filters( 'merlin_timeout_for_downloading_import_file', 20 ) )
+		);
+
+		// Test if the get request was not successful.
+		if ( is_wp_error( $response ) || 200 !== $response['response']['code'] ) {
+			// Collect the right format of error data (array or WP_Error).
+			$response_error = $this->get_error_from_response( $response );
+
+			return new \WP_Error(
+				'download_error',
+				sprintf(
+					__( 'An error occurred while fetching file from: %1$s%2$s%3$s!%4$sReason: %5$s - %6$s.', 'pt-ocdi' ),
+					'<strong>',
+					$url,
+					'</strong>',
+					'<br>',
+					$response_error['error_code'],
+					$response_error['error_message']
+				)
+			);
+		}
+
+		// Return content retrieved from the URL.
+		return wp_remote_retrieve_body( $response );
+	}
+
+
+	/**
+	 * Helper function: get the right format of response errors.
+	 *
+	 * @param array|WP_Error $response Array or WP_Error or the response.
+	 * @return array Error code and error message.
+	 */
+	private function get_error_from_response( $response ) {
+		$response_error = array();
+
+		if ( is_array( $response ) ) {
+			$response_error['error_code']    = $response['response']['code'];
+			$response_error['error_message'] = $response['response']['message'];
+		}
+		else {
+			$response_error['error_code']    = $response->get_error_code();
+			$response_error['error_message'] = $response->get_error_message();
+		}
+
+		return $response_error;
+	}
+
+
+	/**
+	 * Get download_directory_path attribute.
+	 */
+	public function get_download_directory_path() {
+		return $this->download_directory_path;
+	}
+
+
+	/**
+	 * Set download_directory_path attribute.
+	 * If no valid path is specified, the default WP upload directory will be used.
+	 *
+	 * @param string $download_directory_path Path, where the files will be saved.
+	 */
+	public function set_download_directory_path( $download_directory_path ) {
+		if ( file_exists( $download_directory_path ) ) {
+			$this->download_directory_path = $download_directory_path;
+		}
+		else {
+			$upload_dir = wp_upload_dir();
+			$this->download_directory_path = apply_filters( 'merlin_upload_file_path', trailingslashit( $upload_dir['path'] ) );
+		}
+	}
+
+	/**
+	 * Check, if the file already exists and return his full path.
+	 *
+	 * @param string $filename The name of the file.
+	 *
+	 * @return bool|string
+	 */
+	public function fetch_existing_file( $filename ) {
+		if ( file_exists( $this->download_directory_path . $filename ) ) {
+			return $this->download_directory_path . $filename;
+		}
+
+		return false;
+	}
+}

--- a/merlin-config-sample.php
+++ b/merlin-config-sample.php
@@ -19,7 +19,6 @@ $wizard = new Merlin(
 	// Configure Merlin with custom settings.
 	$config = array(
 		'directory'                => '', // Location where the 'merlin' directory is placed.
-		'demo_directory'           => 'demo/', // Location where the theme demo files exist.
 		'merlin_url'               => 'merlin', // Customize the page URL where Merlin WP loads.
 		'child_action_btn_url'     => 'https://codex.wordpress.org/Child_Themes',  // The URL for the 'child-action-link'.
 		'help_mode'                => false, // Set to true to turn on the little wizard helper.

--- a/merlin-filters.php
+++ b/merlin-filters.php
@@ -91,3 +91,93 @@ function prefix_generate_child_functions_php( $output, $slug ) {
 	return $output;
 }
 add_filter( 'merlin_generate_child_functions_php', 'prefix_generate_child_functions_php', 10, 2 );
+
+
+/**
+ * Define the demo import files (remote files).
+ *
+ * To define imports, you just have to add the following code structure,
+ * with your own values to your theme (using the 'merlin_import_files' filter).
+ */
+function merlin_import_files() {
+	return array(
+		array(
+			'import_file_name'           => 'Demo Import 1',
+			'import_file_url'            => 'http://www.your_domain.com/merlin/demo-content.xml',
+			'import_widget_file_url'     => 'http://www.your_domain.com/merlin/widgets.json',
+			'import_customizer_file_url' => 'http://www.your_domain.com/merlin/customizer.dat',
+			'import_preview_image_url'   => 'http://www.your_domain.com/merlin/preview_import_image1.jpg',
+			'import_notice'              => __( 'A special note for this import.', 'your-textdomain' ),
+			'preview_url'                => 'http://www.your_domain.com/my-demo-1',
+		),
+		array(
+			'import_file_name'           => 'Demo Import 2',
+			'import_file_url'            => 'http://www.your_domain.com/merlin/demo-content2.xml',
+			'import_widget_file_url'     => 'http://www.your_domain.com/merlin/widgets2.json',
+			'import_customizer_file_url' => 'http://www.your_domain.com/merlin/customizer2.dat',
+			'import_preview_image_url'   => 'http://www.your_domain.com/merlin/preview_import_image2.jpg',
+			'import_notice'              => __( 'A special note for this import.', 'your-textdomain' ),
+			'preview_url'                => 'http://www.your_domain.com/my-demo-2',
+		),
+	);
+}
+add_filter( 'merlin_import_files', 'merlin_import_files' );
+
+
+/**
+ * Define the demo import files (local files).
+ *
+ * You have to use the same filter as in above example,
+ * but with a slightly different array keys: local_*.
+ * The values have to be absolute paths (not URLs) to your import files.
+ * To use local import files, that reside in your theme folder,
+ * please use the below code.
+ * Note: make sure your import files are readable!
+ */
+function merlin_local_import_files() {
+	return array(
+		array(
+			'import_file_name'             => 'Demo Import 1',
+			'local_import_file'            => trailingslashit( get_template_directory() ) . 'merlin/demo-content.xml',
+			'local_import_widget_file'     => trailingslashit( get_template_directory() ) . 'merlin/widgets.json',
+			'local_import_customizer_file' => trailingslashit( get_template_directory() ) . 'merlin/customizer.dat',
+			'import_preview_image_url'     => 'http://www.your_domain.com/merlin/preview_import_image1.jpg',
+			'import_notice'                => __( 'After you import this demo, you will have to setup the slider separately.', 'your-textdomain' ),
+			'preview_url'                  => 'http://www.your_domain.com/my-demo-1',
+		),
+		array(
+			'import_file_name'             => 'Demo Import 2',
+			'local_import_file'            => trailingslashit( get_template_directory() ) . 'merlin/demo-content2.xml',
+			'local_import_widget_file'     => trailingslashit( get_template_directory() ) . 'merlin/widgets2.json',
+			'local_import_customizer_file' => trailingslashit( get_template_directory() ) . 'merlin/customizer2.dat',
+			'import_preview_image_url'     => 'http://www.your_domain.com/merlin/preview_import_image2.jpg',
+			'import_notice'                => __( 'A special note for this import.', 'your-textdomain' ),
+			'preview_url'                  => 'http://www.your_domain.com/my-demo-2',
+		),
+	);
+}
+add_filter( 'merlin_import_files', 'merlin_local_import_files' );
+
+
+/**
+ * Execute custom code after the whole import has finished.
+ */
+function merlin_after_import_setup() {
+	// Assign menus to their locations.
+	$main_menu = get_term_by( 'name', 'Main Menu', 'nav_menu' );
+
+	set_theme_mod( 'nav_menu_locations', array(
+			'main-menu' => $main_menu->term_id,
+		)
+	);
+
+	// Assign front page and posts page (blog page).
+	$front_page_id = get_page_by_title( 'Home' );
+	$blog_page_id  = get_page_by_title( 'Blog' );
+
+	update_option( 'show_on_front', 'page' );
+	update_option( 'page_on_front', $front_page_id->ID );
+	update_option( 'page_for_posts', $blog_page_id->ID );
+
+}
+add_action( 'merlin_after_all_import', 'merlin_after_import_setup' );

--- a/merlin.php
+++ b/merlin.php
@@ -1455,15 +1455,16 @@ class Merlin {
 
 
 	/**
-	 * Get base sample data
+	 * Get the import files/data.
+	 *
+	 * @param int $selected_import_index The index of the predefined demo import.
 	 *
 	 * @return    array
 	 */
-	protected function get_base_content() {
+	protected function get_import_data( $selected_import_index = 0 ) {
 		$content = array();
 
-		$selected_import_index = 0;
-		$import_files          = $this->get_import_files_paths( $selected_import_index );
+		$import_files = $this->get_import_files_paths( $selected_import_index );
 
 		if ( ! empty( $import_files['content'] ) ) {
 			$content['content'] = array(

--- a/merlin.php
+++ b/merlin.php
@@ -371,6 +371,10 @@ class Merlin {
 		// Enqueue javascript.
 		wp_enqueue_script( 'merlin', get_parent_theme_file_uri( $this->directory . '/merlin/assets/js/merlin' . $suffix . '.js' ), array( 'jquery-core' ), MERLIN_VERSION );
 
+		$texts = array(
+			'something_went_wrong' => esc_html__( 'Something went wrong. Please refresh the page and try again!', '@@textdomain' ),
+		);
+
 		// Localize the javascript.
 		if ( class_exists( 'TGM_Plugin_Activation' ) ) {
 			// Check first if TMGPA is included.
@@ -382,12 +386,14 @@ class Merlin {
 				'tgm_bulk_url'     => $this->tgmpa->get_tgmpa_url(),
 				'ajaxurl'          => admin_url( 'admin-ajax.php' ),
 				'wpnonce'          => wp_create_nonce( 'merlin_nonce' ),
+				'texts'            => $texts,
 			) );
 		} else {
 			// If TMGPA is not included.
 			wp_localize_script( 'merlin', 'merlin_params', array(
 				'ajaxurl' => admin_url( 'admin-ajax.php' ),
 				'wpnonce' => wp_create_nonce( 'merlin_nonce' ),
+				'texts'   => $texts,
 			) );
 		}
 

--- a/merlin.php
+++ b/merlin.php
@@ -66,6 +66,20 @@ class Merlin {
 	protected $hooks;
 
 	/**
+	 * Holds the verified import files.
+	 *
+	 * @var array
+	 */
+	public $import_files;
+
+	/**
+	 * The base import file name.
+	 *
+	 * @var string
+	 */
+	public $import_file_base_name;
+
+	/**
 	 * Helper.
 	 *
 	 * @var    array
@@ -178,6 +192,9 @@ class Merlin {
 		$this->dev_mode             = $config['dev_mode'];
 		$this->branding             = $config['branding'];
 
+		// Set the base name for the import files.
+		$this->set_import_file_base_name();
+
 		// Strings passed in from the config file.
 		$this->strings = $strings;
 
@@ -218,6 +235,7 @@ class Merlin {
 		add_filter( 'pt-importer/new_ajax_request_response_data', array( $this, 'pt_importer_new_ajax_request_response_data' ) );
 		add_action( 'import_end', array( $this, 'after_content_import_setup' ) );
 		add_action( 'import_start', array( $this, 'before_content_import_setup' ) );
+		add_action( 'admin_init', array( $this, 'register_import_files' ) );
 	}
 
 	/**
@@ -227,6 +245,8 @@ class Merlin {
 		if ( ! class_exists( '\WP_Importer' ) ) {
 			require ABSPATH . '/wp-admin/includes/class-wp-importer.php';
 		}
+
+		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-downloader.php' );
 
 		$logger = new ProteusThemes\WPContentImporter2\WPImporterLogger();
 
@@ -647,7 +667,7 @@ class Merlin {
 		}
 
 		// Show the content importer, only if there's demo content added.
-		if ( $this->get_base_content() ) {
+		if ( ! empty( $this->import_files ) ) {
 			$this->steps['content'] = array(
 				'name' => esc_html__( 'Content', '@@textdomain' ),
 				'view' => array( $this, 'content' ),
@@ -1411,9 +1431,10 @@ class Merlin {
 	protected function get_base_content() {
 		$content = array();
 
-		$base_dir = get_parent_theme_file_path( $this->demo_directory );
+		$selected_import_index = 0;
+		$import_files          = $this->get_import_files_paths( $selected_import_index );
 
-		if ( file_exists( $base_dir . 'content.xml' ) ) {
+		if ( ! empty( $import_files['content'] ) ) {
 			$content['content'] = array(
 				'title'             => esc_html__( 'Content', '@@textdomain' ),
 				'description'       => esc_html__( 'Demo content data.', '@@textdomain' ),
@@ -1422,11 +1443,11 @@ class Merlin {
 				'success'           => esc_html__( 'Success', '@@textdomain' ),
 				'checked'           => $this->is_possible_upgrade() ? 0 : 1,
 				'install_callback'  => array( $this->importer, 'import' ),
-				'data'              => $base_dir . 'content.xml',
+				'data'              => $import_files['content'],
 			);
 		}
 
-		if ( file_exists( $base_dir . 'widgets.wie' ) ) {
+		if ( ! empty( $import_files['widgets'] )  ) {
 			$content['widgets'] = array(
 				'title'            => esc_html__( 'Widgets', '@@textdomain' ),
 				'description'      => esc_html__( 'Sample widgets data.', '@@textdomain' ),
@@ -1435,11 +1456,11 @@ class Merlin {
 				'success'          => esc_html__( 'Success', '@@textdomain' ),
 				'install_callback' => array( 'Merlin_Widget_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
-				'data'             => $base_dir . 'widgets.wie',
+				'data'             => $import_files['widgets'],
 			);
 		}
 
-		if ( file_exists( $base_dir . 'slider.zip' ) ) {
+		if ( ! empty( $import_files['sliders'] )  ) {
 			$content['sliders'] = array(
 				'title'            => esc_html__( 'Revolution Slider', '@@textdomain' ),
 				'description'      => esc_html__( 'Sample Revolution sliders data.', '@@textdomain' ),
@@ -1448,11 +1469,11 @@ class Merlin {
 				'success'          => esc_html__( 'Success', '@@textdomain' ),
 				'install_callback' => array( $this, 'import_revolution_sliders' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
-				'data'             => $base_dir . 'slider.zip',
+				'data'             => $import_files['sliders'],
 			);
 		}
 
-		if ( file_exists( $base_dir . 'customizer.dat' ) ) {
+		if ( ! empty( $import_files['options'] )  ) {
 			$content['options'] = array(
 				'title'            => esc_html__( 'Options', '@@textdomain' ),
 				'description'      => esc_html__( 'Sample theme options data.', '@@textdomain' ),
@@ -1461,7 +1482,7 @@ class Merlin {
 				'success'          => esc_html__( 'Success', '@@textdomain' ),
 				'install_callback' => array( 'Merlin_Customizer_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
-				'data'             => $base_dir . 'customizer.dat',
+				'data'             => $import_files['options'],
 			);
 		}
 
@@ -1553,5 +1574,170 @@ class Merlin {
 			$hello_world->post_status = 'draft';
 			wp_update_post( $hello_world );
 		}
+	}
+
+	/**
+	 * Register the import files via the `merlin_import_files` filter.
+	 */
+	public function register_import_files() {
+		$this->import_files = $this->validate_import_file_info( apply_filters( 'merlin_import_files', array() ) );
+	}
+
+	/**
+	 * Filter through the array of import files and get rid of those who do not comply.
+	 *
+	 * @param  array $import_files list of arrays with import file details.
+	 * @return array list of filtered arrays.
+	 */
+	public function validate_import_file_info( $import_files ) {
+		$filtered_import_file_info = array();
+
+		foreach ( $import_files as $import_file ) {
+			if ( ! empty( $import_file['import_file_name'] ) ) {
+				$filtered_import_file_info[] = $import_file;
+			}
+		}
+
+		return $filtered_import_file_info;
+	}
+
+	/**
+	 * Set the import file base name.
+	 * Check if an existing base name is available (saved in a transient).
+	 */
+	public function set_import_file_base_name() {
+		$existing_name = get_transient( 'merlin_import_file_base_name' );
+
+		if ( ! empty( $existing_name ) ) {
+			$this->import_file_base_name = $existing_name;
+		}
+		else {
+			$this->import_file_base_name = date( 'Y-m-d__H-i-s' );
+			set_transient( 'merlin_import_file_base_name', $this->import_file_base_name, 5 * MINUTE_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Get the import file paths.
+	 * Grab the defined local paths, download the files or reuse existing files.
+	 *
+	 * @param int $selected_import_index The index of the selected import.
+	 *
+	 * @return array
+	 */
+	public function get_import_files_paths( $selected_import_index ) {
+		$selected_import_data = empty( $this->import_files[ $selected_import_index ] ) ? false : $this->import_files[ $selected_import_index ];
+
+		if ( empty( $selected_import_data ) ) {
+			return array();
+		}
+
+		$base_file_name = $this->import_file_base_name;
+		$import_files   = array(
+			'content' => '',
+			'widgets' => '',
+			'options' => '',
+			'sliders' => '',
+		);
+
+		$downloader = new Merlin_Downloader();
+
+		// Check if 'import_file_url' is not defined. That would mean a local file.
+		if ( empty( $selected_import_data['import_file_url'] ) ) {
+			if ( file_exists( $selected_import_data['local_import_file'] ) ) {
+				$import_files['content'] = $selected_import_data['local_import_file'];
+			}
+		}
+		else {
+			// Set the filename string for content import file.
+			$content_filename = 'content-' . $base_file_name . '.xml';
+
+			// Retrieve the content import file.
+			$import_files['content'] = $downloader->fetch_existing_file( $content_filename );
+
+			// Download the file, if it's missing.
+			if ( empty( $import_files['content'] ) ) {
+				$import_files['content'] = $downloader->download_file( $selected_import_data['import_file_url'], $content_filename );
+			}
+
+			// Reset the variable, if there was an error.
+			if ( is_wp_error( $import_files['content'] ) ) {
+				$import_files['content'] = '';
+			}
+		}
+
+		// Get widgets file as well. If defined!
+		if ( ! empty( $selected_import_data['import_widget_file_url'] ) ) {
+			// Set the filename string for widgets import file.
+			$widget_filename = 'widgets-' . $base_file_name . '.json';
+
+			// Retrieve the content import file.
+			$import_files['widgets'] = $downloader->fetch_existing_file( $widget_filename );
+
+			// Download the file, if it's missing.
+			if ( empty( $import_files['widgets'] ) ) {
+				$import_files['widgets'] = $downloader->download_file( $selected_import_data['import_widget_file_url'], $widget_filename );
+			}
+
+			// Reset the variable, if there was an error.
+			if ( is_wp_error( $import_files['widgets'] ) ) {
+				$import_files['widgets'] = '';
+			}
+		}
+		else if ( ! empty( $selected_import_data['local_import_widget_file'] ) ) {
+			if ( file_exists( $selected_import_data['local_import_widget_file'] ) ) {
+				$import_files['widgets'] = $selected_import_data['local_import_widget_file'];
+			}
+		}
+
+		// Get customizer import file as well. If defined!
+		if ( ! empty( $selected_import_data['import_customizer_file_url'] ) ) {
+			// Setup filename path to save the customizer content.
+			$customizer_filename = 'options-' . $base_file_name . '.dat';
+
+			// Retrieve the content import file.
+			$import_files['options'] = $downloader->fetch_existing_file( $customizer_filename );
+
+			// Download the file, if it's missing.
+			if ( empty( $import_files['options'] ) ) {
+				$import_files['options'] = $downloader->download_file( $selected_import_data['import_customizer_file_url'], $customizer_filename );
+			}
+
+			// Reset the variable, if there was an error.
+			if ( is_wp_error( $import_files['options'] ) ) {
+				$import_files['options'] = '';
+			}
+		}
+		else if ( ! empty( $selected_import_data['local_import_customizer_file'] ) ) {
+			if ( file_exists( $selected_import_data['local_import_customizer_file'] ) ) {
+				$import_files['options'] = $selected_import_data['local_import_customizer_file'];
+			}
+		}
+
+		// Get revolution slider import file as well. If defined!
+		if ( ! empty( $selected_import_data['import_rev_slider_file_url'] ) ) {
+			// Setup filename path to save the customizer content.
+			$rev_slider_filename = 'slider' . $base_file_name . '.zip';
+
+			// Retrieve the content import file.
+			$import_files['sliders'] = $downloader->fetch_existing_file( $rev_slider_filename );
+
+			// Download the file, if it's missing.
+			if ( empty( $import_files['sliders'] ) ) {
+				$import_files['sliders'] = $downloader->download_file( $selected_import_data['import_rev_slider_file_url'], $rev_slider_filename );
+			}
+
+			// Reset the variable, if there was an error.
+			if ( is_wp_error( $import_files['sliders'] ) ) {
+				$import_files['sliders'] = '';
+			}
+		}
+		else if ( ! empty( $selected_import_data['local_import_rev_slider_file'] ) ) {
+			if ( file_exists( $selected_import_data['local_import_rev_slider_file'] ) ) {
+				$import_files['sliders'] = $selected_import_data['local_import_rev_slider_file'];
+			}
+		}
+
+		return $import_files;
 	}
 }

--- a/merlin.php
+++ b/merlin.php
@@ -1677,7 +1677,7 @@ class Merlin {
 
 		// Check if 'import_file_url' is not defined. That would mean a local file.
 		if ( empty( $selected_import_data['import_file_url'] ) ) {
-			if ( file_exists( $selected_import_data['local_import_file'] ) ) {
+			if ( ! empty( $selected_import_data['local_import_file'] ) && file_exists( $selected_import_data['local_import_file'] ) ) {
 				$import_files['content'] = $selected_import_data['local_import_file'];
 			}
 		}

--- a/merlin.php
+++ b/merlin.php
@@ -969,24 +969,25 @@ class Merlin {
 
 			<p><?php echo esc_html( $paragraph ); ?></p>
 
+			<?php if ( 1 < count( $this->import_files ) ) : ?>
+				<p><?php esc_html_e( 'Select which demo data you want to import:', '@@textdomain' ); ?></p>
+				<select class="js-merlin-demo-import-select">
+					<?php foreach ( $this->import_files as $index => $import_file ) : ?>
+						<?php
+						$img_src          = isset( $import_file['import_preview_image_url'] ) ? $import_file['import_preview_image_url'] : '';
+						$import_notice    = isset( $import_file['import_notice'] ) ? $import_file['import_notice'] : '';
+						$demo_preview_url = isset( $import_file['preview_url'] ) ? $import_file['preview_url'] : '';
+						?>
+
+						<option value="<?php echo esc_attr( $index ); ?>" data-img-src="<?php echo esc_url( $img_src ); ?>" data-notice="<?php echo esc_html( $import_notice ); ?>" data-preview-url="<?php echo esc_url( $demo_preview_url ); ?>"><?php echo esc_html( $import_file['import_file_name'] ); ?></option>
+
+					<?php endforeach; ?>
+				</select>
+			<?php endif; ?>
+
 			<a id="merlin__drawer-trigger" class="merlin__button merlin__button--knockout"><span><?php echo esc_html( $action ); ?></span><span class="chevron"></span></a>
 
 		</div>
-
-		<form action="" method="post">
-
-			<ul class="merlin__drawer merlin__drawer--import-content">
-				<?php
-				foreach ( $content as $slug => $default ) :
-
-					if ( 'baseurl' === $slug || 'version' === $slug ) {
-						continue;
-					}
-
-					if ( 'users' === $slug ) {
-						$default['checked'] = false;
-					}
-					?>
 
 					<li class="merlin__drawer--import-content__list-item status status--<?php echo esc_attr( $default['pending'] ); ?>" data-content="<?php echo esc_attr( $slug ); ?>">
 						<input type="checkbox" name="default_content[<?php echo esc_attr( $slug ); ?>]" class="checkbox" id="default_content_<?php echo esc_attr( $slug ); ?>" value="1" <?php echo ( ! isset( $default['checked'] ) || $default['checked'] ) ? ' checked' : ''; ?>>

--- a/merlin.php
+++ b/merlin.php
@@ -1524,7 +1524,7 @@ class Merlin {
 				'success'          => esc_html__( 'Success', '@@textdomain' ),
 				'install_callback' => array( $this->hooks, 'after_all_import_action' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
-				'data'             => 0,
+				'data'             => $selected_import_index,
 			);
 		}
 

--- a/merlin.php
+++ b/merlin.php
@@ -942,8 +942,7 @@ class Merlin {
 	 * Page setup
 	 */
 	protected function content() {
-		// Retrieve the content to import.
-		$content = $this->get_base_content();
+		$import_info = $this->get_import_data_info();
 
 		// Strings passed in from the config file.
 		$strings = $this->strings;
@@ -989,14 +988,10 @@ class Merlin {
 
 		</div>
 
-					<li class="merlin__drawer--import-content__list-item status status--<?php echo esc_attr( $default['pending'] ); ?>" data-content="<?php echo esc_attr( $slug ); ?>">
-						<input type="checkbox" name="default_content[<?php echo esc_attr( $slug ); ?>]" class="checkbox" id="default_content_<?php echo esc_attr( $slug ); ?>" value="1" <?php echo ( ! isset( $default['checked'] ) || $default['checked'] ) ? ' checked' : ''; ?>>
-						<label for="default_content_<?php echo esc_attr( $slug ); ?>">
-							<i></i><span><?php echo esc_html( $default['title'] ); ?></span>
-						</label>
-					</li>
+		<form action="" method="post">
 
-				<?php endforeach; ?>
+			<ul class="merlin__drawer merlin__drawer--import-content js-merlin-drawer-import-content">
+				<?php echo $this->get_import_steps_html( $import_info ); ?>
 			</ul>
 
 			<footer class="merlin__content__footer">
@@ -1396,6 +1391,64 @@ class Merlin {
 			) );
 		}
 	}
+
+
+	/**
+	 * Get import data from the selected import.
+	 * Which data does the selected import have for the import.
+	 *
+	 * @param int $selected_import_index The index of the predefined demo import.
+	 *
+	 * @return bool|array
+	 */
+	public function get_import_data_info( $selected_import_index = 0 ) {
+		$import_data = array(
+			'content'      => false,
+			'widgets'      => false,
+			'options'      => false,
+			'sliders'      => false,
+			'after_import' => false,
+		);
+
+		if ( empty( $this->import_files[ $selected_import_index ] ) ) {
+			return false;
+		}
+
+		if (
+			! empty( $this->import_files[ $selected_import_index ]['import_file_url'] ) ||
+			! empty( $this->import_files[ $selected_import_index ]['local_import_file'] )
+		) {
+			$import_data['content'] = true;
+		}
+
+		if (
+			! empty( $this->import_files[ $selected_import_index ]['import_widget_file_url'] ) ||
+			! empty( $this->import_files[ $selected_import_index ]['local_import_widget_file'] )
+		) {
+			$import_data['widgets'] = true;
+		}
+
+		if (
+			! empty( $this->import_files[ $selected_import_index ]['import_customizer_file_url'] ) ||
+			! empty( $this->import_files[ $selected_import_index ]['local_import_customizer_file'] )
+		) {
+			$import_data['options'] = true;
+		}
+
+		if (
+			! empty( $this->import_files[ $selected_import_index ]['import_rev_slider_file_url'] ) ||
+			! empty( $this->import_files[ $selected_import_index ]['local_import_rev_slider_file'] )
+		) {
+			$import_data['sliders'] = true;
+		}
+
+		if ( false !== has_action( 'merlin_after_all_import' ) ) {
+			$import_data['after_import'] = true;
+		}
+
+		return $import_data;
+	}
+
 
 	/**
 	 * Get base sample data

--- a/merlin.php
+++ b/merlin.php
@@ -1642,8 +1642,9 @@ class Merlin {
 		}
 		else {
 			$this->import_file_base_name = date( 'Y-m-d__H-i-s' );
-			set_transient( 'merlin_import_file_base_name', $this->import_file_base_name, 5 * MINUTE_IN_SECONDS );
 		}
+
+		set_transient( 'merlin_import_file_base_name', $this->import_file_base_name, MINUTE_IN_SECONDS );
 	}
 
 	/**

--- a/merlin.php
+++ b/merlin.php
@@ -183,9 +183,6 @@ class Merlin {
 		$this->dev_mode             = $config['dev_mode'];
 		$this->branding             = $config['branding'];
 
-		// Set the base name for the import files.
-		$this->set_import_file_base_name();
-
 		// Strings passed in from the config file.
 		$this->strings = $strings;
 
@@ -1601,6 +1598,9 @@ class Merlin {
 		if ( empty( $selected_import_data ) ) {
 			return array();
 		}
+
+		// Set the base name for the import files.
+		$this->set_import_file_base_name();
 
 		$base_file_name = $this->import_file_base_name;
 		$import_files   = array(

--- a/merlin.php
+++ b/merlin.php
@@ -1344,8 +1344,10 @@ class Merlin {
 	function _ajax_content() {
 		static $content = null;
 
+		$selected_import = intval( $_POST['selected_index'] );
+
 		if ( null === $content ) {
-			$content = $this->get_base_content();
+			$content = $this->get_import_data( $selected_import );
 		}
 
 		if ( ! check_ajax_referer( 'merlin_nonce', 'wpnonce' ) || empty( $_POST['content'] ) && isset( $content[ $_POST['content'] ] ) ) {

--- a/merlin.php
+++ b/merlin.php
@@ -108,13 +108,6 @@ class Merlin {
 	protected $directory = null;
 
 	/**
-	 * The location where the demo content is located within the theme.
-	 *
-	 * @var string $demo_directory
-	 */
-	protected $demo_directory = null;
-
-	/**
 	 * Top level admin page.
 	 *
 	 * @var string $merlin_url
@@ -175,7 +168,6 @@ class Merlin {
 
 		$config = wp_parse_args( $config, array(
 			'directory'            => '',
-			'demo_directory'       => '',
 			'merlin_url'           => 'merlin',
 			'child_action_btn_url' => '',
 			'help_mode'            => '',
@@ -185,7 +177,6 @@ class Merlin {
 
 		// Set config arguments.
 		$this->directory            = $config['directory'];
-		$this->demo_directory       = $config['demo_directory'];
 		$this->merlin_url           = $config['merlin_url'];
 		$this->child_action_btn_url = $config['child_action_btn_url'];
 		$this->help_mode            = $config['help_mode'];
@@ -298,25 +289,6 @@ class Merlin {
 		wp_safe_redirect( admin_url( 'themes.php?page= ' . $this->merlin_url ) );
 
 		exit;
-	}
-
-	/**
-	 * Remove default sidebar widgets.
-	 */
-	protected function unset_default_widgets() {
-
-		$base_dir = get_parent_theme_file_path( $this->demo_directory );
-
-		// If the widgets.wie file does not exist, then let's not remove the default widgets, as there are none to replace them with.
-		if ( ! file_exists( $base_dir . 'widgets.wie' ) ) {
-			return;
-		}
-
-		$widget_areas = array(
-			'sidebar-1' => array(),
-		);
-
-		update_option( 'sidebars_widgets', apply_filters( 'merlin_unset_default_widgets_args', $widget_areas ) );
 	}
 
 	/**
@@ -1036,8 +1008,6 @@ class Merlin {
 				<?php wp_nonce_field( 'merlin' ); ?>
 			</footer>
 		</form>
-
-		<?php $this->unset_default_widgets(); ?>
 
 	<?php
 	}


### PR DESCRIPTION
We added the option to select which predefined demo to import.

If the theme has multiple demo imports defined in the `merlin_import_files` filter, then a dropdown will be displayed in the import step of the wizard. For now it's just the names of the imports in a dropdown, but other data is prepared (demo preview URL, demo preview image URL and an import notice), for each predefined demo import.

The code of PR: https://github.com/richtabor/MerlinWP/pull/42 is also in this PR, because that PR is not yet merge to the master... So I suggest reviewing/merging the PR 42 first and then this one.
