### PR TITLE
Fix merlin file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ If you have TGMPA included within your theme, please ensure Merlin WP is include
 The `merlin-config.php` file tells Merlin WP where the class is installed. In this config file, you can also enable the Easy Digital Downloads license activation step. It also let's you modify any of the text strings throughout the wizard.
 
 ** The important configuration settings: **
-* `directory` — The location in your theme where the `/merlin/` directory is placed
+* `directory` — The location in your theme where the merlin code directory is placed (example: `inc/merlin`, if you placed the `merlin` folder in your theme's `inc` folder)
 
 Other settings:
-* `merlin_url` — The admin url where Merlin WP will exist
+* `merlin_url` — The admin url slug where Merlin WP will exist
 * `child_action_btn_url` — The url for the child theme generator's "Learn more" link
 * `theme_license_step` - Set to true to turn on the license activation step (compatible with Easy Digital Downloads Licensing addon)
 * `theme_license_btn_url` - (only if theme_license_step is enabled) The url to a website explaining, where the user can get the EDD license key.

--- a/merlin-config-sample.php
+++ b/merlin-config-sample.php
@@ -18,8 +18,8 @@ if ( ! class_exists( 'Merlin' ) ) {
 $wizard = new Merlin(
 	// Configure Merlin with custom settings.
 	$config = array(
-		'directory'                => '', // Location where the 'merlin' directory is placed.
-		'merlin_url'               => 'merlin', // Customize the page URL where Merlin WP loads.
+		'directory'                => 'merlin', // Location where the 'merlin' directory is placed in your theme.
+		'merlin_url'               => 'merlin', // Customize the page URL where Merlin WP loads (wp-admin page slug).
 		'child_action_btn_url'     => 'https://codex.wordpress.org/Child_Themes',  // The URL for the 'child-action-link'.
 		'theme_license_step'       => false, // Set to true to turn on the license activation step (compatible with Easy Digital Downloads Licensing addon)
 		'theme_license_btn_url'    => 'https://your-domain.com/link-to-the-support-article', // The URL for the 'theme-license-action-link'.

--- a/merlin.php
+++ b/merlin.php
@@ -202,7 +202,7 @@ class Merlin {
 		$this->version();
 
 		$config = wp_parse_args( $config, array(
-			'directory'            => '',
+			'directory'            => 'merlin',
 			'merlin_url'           => 'merlin',
 			'child_action_btn_url' => '',
 			'help_mode'            => '',
@@ -276,24 +276,24 @@ class Merlin {
 			require ABSPATH . '/wp-admin/includes/class-wp-importer.php';
 		}
 
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-downloader.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-downloader.php' );
 
 		$logger = new ProteusThemes\WPContentImporter2\WPImporterLogger();
 
 		$this->importer = new ProteusThemes\WPContentImporter2\Importer( array( 'fetch_attachments' => true ), $logger );
 
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-widget-importer.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-widget-importer.php' );
 
 		if ( ! class_exists( 'WP_Customize_Setting' ) ) {
 			require_once ABSPATH . 'wp-includes/class-wp-customize-setting.php';
 		}
 
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-customizer-option.php' );
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-customizer-importer.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-customizer-option.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-customizer-importer.php' );
 
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-redux-importer.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-redux-importer.php' );
 
-		require_once get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-hooks.php' );
+		require_once get_parent_theme_file_path( $this->directory . '/includes/class-merlin-hooks.php' );
 
 		$this->hooks = new Merlin_Hooks();
 
@@ -302,7 +302,7 @@ class Merlin {
 		}
 
 		if ( true === $this->help_mode ) {
-			require get_parent_theme_file_path( $this->directory . '/merlin/includes/class-merlin-helper.php' );
+			require get_parent_theme_file_path( $this->directory . '/includes/class-merlin-helper.php' );
 			$this->helper = new Merlin_Helper();
 		}
 	}
@@ -410,10 +410,10 @@ class Merlin {
 		$suffix = ( ( true == $this->dev_mode ) ) ? '' : '.min';
 
 		// Enqueue styles.
-		wp_enqueue_style( 'merlin', get_parent_theme_file_uri( $this->directory . '/merlin/assets/css/merlin' . $suffix . '.css' ), array( 'wp-admin' ), MERLIN_VERSION );
+		wp_enqueue_style( 'merlin', get_parent_theme_file_uri( $this->directory . '/assets/css/merlin' . $suffix . '.css' ), array( 'wp-admin' ), MERLIN_VERSION );
 
 		// Enqueue javascript.
-		wp_enqueue_script( 'merlin', get_parent_theme_file_uri( $this->directory . '/merlin/assets/js/merlin' . $suffix . '.js' ), array( 'jquery-core' ), MERLIN_VERSION );
+		wp_enqueue_script( 'merlin', get_parent_theme_file_uri( $this->directory . '/assets/js/merlin' . $suffix . '.js' ), array( 'jquery-core' ), MERLIN_VERSION );
 
 		$texts = array(
 			'something_went_wrong' => esc_html__( 'Something went wrong. Please refresh the page and try again!', '@@textdomain' ),
@@ -543,7 +543,7 @@ class Merlin {
 	public function svg_sprite() {
 
 		// Define SVG sprite file.
-		$svg = get_parent_theme_file_path( $this->directory . '/merlin/assets/images/sprite.svg' );
+		$svg = get_parent_theme_file_path( $this->directory . '/assets/images/sprite.svg' );
 
 		// If it exists, include it.
 		if ( file_exists( $svg ) ) {
@@ -652,7 +652,7 @@ class Merlin {
 	public function loading_spinner() {
 
 		// Define the spinner file.
-		$spinner = $this->directory . '/merlin/assets/images/spinner';
+		$spinner = $this->directory . '/assets/images/spinner';
 
 		// Retrieve the spinner.
 		get_template_part( apply_filters( 'merlin_loading_spinner', $spinner ) );


### PR DESCRIPTION
Fixes #34 

@richtabor This will make the loading of MerlinWP files more flexible.

For example, theme authors which will load MerlinWP with PHP composer will be able to change the `directory` config to `vendor/richtabor/merlin-wp` and the files will load OK.

What do you think?