### PR TITLE
License Requirement

### DIFF
--- a/merlin-config-sample.php
+++ b/merlin-config-sample.php
@@ -18,15 +18,16 @@ if ( ! class_exists( 'Merlin' ) ) {
 $wizard = new Merlin(
 
 	$config  = array(
-		'directory'             => 'merlin', // Location / directory where Merlin WP is placed in your theme.
-		'merlin_url'            => 'merlin',  // The wp-admin page slug where Merlin WP loads.
-		'child_action_btn_url'  => 'https://codex.wordpress.org/child_themes', // URL for the 'child-action-link'.
-		'dev_mode'              => false,
-		'theme_license_step'    => false, // EDD license activation step.
-		'edd_remote_api_url'    => '', // EDD_Theme_Updater_Admin remote_api_url.
-		'edd_item_name'         => '', // EDD_Theme_Updater_Admin item_name.
-		'edd_theme_slug'        => '', // EDD_Theme_Updater_Admin item_slug.
-		'theme_license_btn_url' => '', // URL for the 'theme-license-action-link'.
+		'directory'              => 'merlin', // Location / directory where Merlin WP is placed in your theme.
+		'merlin_url'             => 'merlin',  // The wp-admin page slug where Merlin WP loads.
+		'child_action_btn_url'   => 'https://codex.wordpress.org/child_themes', // URL for the 'child-action-link'.
+		'dev_mode'               => false, // Enable development mode for testing.
+		'theme_license_step'     => false, // EDD license activation step.
+		'theme_license_required' => true, // Require the license activation step.
+		'edd_remote_api_url'     => '', // EDD_Theme_Updater_Admin remote_api_url.
+		'edd_item_name'          => '', // EDD_Theme_Updater_Admin item_name.
+		'edd_theme_slug'         => '', // EDD_Theme_Updater_Admin item_slug.
+		'theme_license_btn_url'  => '', // URL for the 'theme-license-action-link'.
 	),
 	$strings = array(
 		'admin-menu'                   => esc_html__( 'Theme Setup', '@@textdomain' ),

--- a/merlin-config-sample.php
+++ b/merlin-config-sample.php
@@ -23,11 +23,11 @@ $wizard = new Merlin(
 		'child_action_btn_url'   => 'https://codex.wordpress.org/child_themes', // URL for the 'child-action-link'.
 		'dev_mode'               => false, // Enable development mode for testing.
 		'theme_license_step'     => false, // EDD license activation step.
-		'theme_license_required' => true, // Require the license activation step.
+		'theme_license_required' => false, // Require the license activation step.
+		'theme_license_btn_url'  => '', // URL for the 'theme-license-action-link'.
 		'edd_remote_api_url'     => '', // EDD_Theme_Updater_Admin remote_api_url.
 		'edd_item_name'          => '', // EDD_Theme_Updater_Admin item_name.
 		'edd_theme_slug'         => '', // EDD_Theme_Updater_Admin item_slug.
-		'theme_license_btn_url'  => '', // URL for the 'theme-license-action-link'.
 	),
 	$strings = array(
 		'admin-menu'                   => esc_html__( 'Theme Setup', '@@textdomain' ),
@@ -45,6 +45,7 @@ $wizard = new Merlin(
 		'btn-content-install'          => esc_html__( 'Install', '@@textdomain' ),
 		'btn-import'                   => esc_html__( 'Import', '@@textdomain' ),
 		'btn-theme-license-install'    => esc_html__( 'Activate', '@@textdomain' ),
+		'btn-theme-license-skip'       => esc_html__( 'Later', '@@textdomain' ),
 
 		/* translators: Theme Name */
 		'theme-license-header%s'       => esc_html__( 'Activate %s', '@@textdomain' ),

--- a/merlin.php
+++ b/merlin.php
@@ -136,6 +136,13 @@ class Merlin {
 	protected $theme_license_action_btn_url = null;
 
 	/**
+	 * Remove the "Skip" button, if required.
+	 *
+	 * @var string $theme_license_required
+	 */
+	protected $theme_license_required = null;
+
+	/**
 	 * The item name of the EDD product (this theme).
 	 *
 	 * @var string $edd_item_name
@@ -200,6 +207,7 @@ class Merlin {
 		$this->child_action_btn_url         = $config['child_action_btn_url'];
 		$this->theme_license_step_enabled   = $config['theme_license_step'];
 		$this->theme_license_action_btn_url = $config['theme_license_btn_url'];
+		$this->theme_license_required       = $config['theme_license_required'];
 		$this->edd_item_name                = $config['edd_item_name'];
 		$this->edd_theme_slug               = $config['edd_theme_slug'];
 		$this->edd_remote_api_url           = $config['edd_remote_api_url'];
@@ -766,6 +774,7 @@ class Merlin {
 	protected function theme_edd_license() {
 		$is_theme_registered = $this->is_theme_registered();
 		$action_url          = $this->theme_license_action_btn_url;
+		$required            = $this->theme_license_required;
 
 		// Theme Name.
 		$theme = ucfirst( $this->theme );
@@ -814,6 +823,10 @@ class Merlin {
 		<footer class="merlin__content__footer">
 
 			<?php if ( ! $is_theme_registered ) : ?>
+
+				<?php if ( ! $required ) : ?>
+					<a href="<?php echo esc_url( $this->step_next_link() ); ?>" class="merlin__button merlin__button--skip merlin__button--proceed"><?php echo esc_html( $skip ); ?></a>
+				<?php endif ?>
 
 				<a href="<?php echo esc_url( $this->step_next_link() ); ?>" class="merlin__button merlin__button--next button-next js-merlin-theme-license-activate-button" data-callback="activate_license">
 					<span class="merlin__button--loading__text"><?php echo esc_html( $install ); ?></span><?php echo $this->loading_spinner(); ?>

--- a/merlin.php
+++ b/merlin.php
@@ -789,7 +789,7 @@ class Merlin {
 		$header    = ! $is_theme_registered ? $strings['theme-license-header%s'] : $strings['theme-license-header-success'];
 		$action    = $strings['theme-license-action-link'];
 		$label     = $strings['theme-license-label'];
-		$skip      = $strings['btn-skip'];
+		$skip      = $strings['btn-theme-license-skip'];
 		$next      = $strings['btn-next'];
 		$paragraph = ! $is_theme_registered ? $strings['theme-license%s'] : $strings['theme-license-success%s'];
 		$install   = $strings['btn-theme-license-install'];


### PR DESCRIPTION
Add a `theme_license_required` config option to require a license activation. If required, the license’s “Skip” button will be unavailable.

There’s also a new text string to modify the “Skip” button on the license page.

