### PR TITLE
Add an action to ignore Merlin WP

### DIFF
--- a/assets/scss/modules/_back-to-dashboard.scss
+++ b/assets/scss/modules/_back-to-dashboard.scss
@@ -1,9 +1,10 @@
 .return-to-dashboard {
 	color: $gray;
 	display: block;
-	padding: 1em;
 	font-size: 13px;
 	margin-top: 1em;
+	padding: 1em;
+	padding-bottom: 0;
 	text-align: center;
 	text-decoration: none;
 	transition: color 150ms ease, opacity 300ms cubic-bezier(.694, 0, .335, 1) 150ms;
@@ -20,8 +21,18 @@
 	.merlin__body--welcome.loaded & {
 		opacity: 1;
 	}
+
+	&.ignore {
+		margin-top: .3em;
+		padding: 0;
+	}
+
+	body:not(.merlin__body--welcome) &.ignore {
+		opacity: 0;
+		pointer-events: none;
+	}
 }
 
 .return-to-dashboard:hover {
-	color: #0073aa;
+	color: $blue;
 }

--- a/merlin-config-sample.php
+++ b/merlin-config-sample.php
@@ -37,6 +37,7 @@ $wizard = new Merlin(
 		/* translators: 1: Title Tag 2: Theme Name 3: Closing Title Tag */
 		'title%s%s%s%s'            => esc_html__( '%1$s%2$s Themes &lsaquo; Theme Setup: %3$s%4$s', '@@textdomain' ),
 		'return-to-dashboard'      => esc_html__( 'Return to the dashboard', '@@textdomain' ),
+		'ignore'                   => esc_html__( 'Disable this wizard', '@@textdomain' ),
 
 		'btn-skip'                 => esc_html__( 'Skip', '@@textdomain' ),
 		'btn-next'                 => esc_html__( 'Next', '@@textdomain' ),


### PR DESCRIPTION
Useful for folks who already have their sites setup, or simply never want to go through the setup process. Sets the existing `merlin_slug_completed` option to `ignored`. 

Once ignored, Merlin WP goes away. 👍

The action link is only available on the first step of the wizard, as there's no reason to disable the wizard in the middle of the setup process. There's also a new text string `ignore` to modify the text.

<img width="904" alt="screen shot 2018-04-04 at 2 04 38 pm" src="https://user-images.githubusercontent.com/1813435/38325753-ef362162-3811-11e8-8a93-25cedcc96094.png">