### PR TITLE
Reset WP is now WP Reset at a new URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ A log file is created in `.../wp-content/uploads/merlin-wp/main.log`. In the log
 
 ### 7. Testing
 
-To test, you'll want to create a new standard WordPress installation and add your theme build with Merlin WP integrated. You can then use the [Reset WP](https://wordpress.org/plugins/reset-wp/) plugin to reset and run through more tests.
+To test, you'll want to create a new standard WordPress installation and add your theme build with Merlin WP integrated. You can then use the [WP Reset](https://wordpress.org/plugins/wp-reset/) plugin to reset and run through more tests.
 
 ## Contributions
 


### PR DESCRIPTION
Saves the step of downloading 1 plugin just to find out they moved it and we need to download a new one. Not sure why they did that, but whatever, let’s just point to the new one.