### PR TITLE
Update class-merlin.php

### DIFF
--- a/class-merlin.php
+++ b/class-merlin.php
@@ -370,7 +370,7 @@ class Merlin {
 
 		delete_transient( $this->theme->template . '_merlin_redirect' );
 
-		wp_safe_redirect( menu_page_url( $this->merlin_url ) );
+		wp_safe_redirect( menu_page_url( $this->merlin_url, false ) );
 
 		exit;
 	}


### PR DESCRIPTION
Added `false` as second parameter to `menu_page_url()` to make sure it `returns` the result. By default, `menu_page_url` echoes the output which was causing issues on my server. I was getting a white-screen and "Headers already sent" error (with `WP_DEBUG` enabled) as soon as the theme is activated and WordPress redirects to merlin theme wizard.

Following is an example screenshot:
![image](https://user-images.githubusercontent.com/10553273/50523894-5ec86480-0af4-11e9-9dba-9704ab30df22.png)
