### PR TITLE
Fix #156

### DIFF
--- a/class-merlin.php
+++ b/class-merlin.php
@@ -370,7 +370,7 @@ class Merlin {
 
 		delete_transient( $this->theme->template . '_merlin_redirect' );
 
-		wp_safe_redirect( menu_page_url( $this->merlin_url ) );
+		wp_safe_redirect( menu_page_url( $this->merlin_url, false ) );
 
 		exit;
 	}


### PR DESCRIPTION
Fix issue while activating the theme with Merlin WP. After activating theme, `"Cannot modify header information`" notice is thrown by the plugin. 