### PR TITLE
Fixing issue #169 – SVG illustrations are off in Chrome

### DIFF
--- a/assets/images/sprite.svg
+++ b/assets/images/sprite.svg
@@ -9,7 +9,7 @@
 	<g data-name="Group"><path data-name="Compound Path" d="M50,17.6A32.4,32.4,0,1,0,82.4,50,32.4,32.4,0,0,0,50,17.6Zm3.2,47.7H47.1v-6h6.2ZM59.1,48a15.4,15.4,0,0,1-3,2.8L54.6,52a4.4,4.4,0,0,0-1.6,2.2,9.1,9.1,0,0,0-.3,2.4H47.2a16.2,16.2,0,0,1,.7-4.8,8.5,8.5,0,0,1,2.8-3.1l1.5-1.2a5.3,5.3,0,0,0,1.2-1.2,4.2,4.2,0,0,0,.8-2.5,4.8,4.8,0,0,0-.9-2.9q-.9-1.3-3.3-1.3a3.7,3.7,0,0,0-3.4,1.6,6.1,6.1,0,0,0-1,3.3h-6q.2-5.9,4.1-8.3a10.8,10.8,0,0,1,6-1.6,12.9,12.9,0,0,1,7.7,2.2,7.6,7.6,0,0,1,3.1,6.6A7.5,7.5,0,0,1,59.1,48Z"></path></g>
 </symbol>
 
-<symbol id="icon-welcome" width="166px" height="105px" viewBox="0 0 166 105" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-welcome" viewBox="0 0 166 105" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Getting-Started">
@@ -126,7 +126,7 @@
 </symbol>
 
 
-<symbol id="icon-done" width="177px" height="107px" viewBox="0 0 177 107" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-done" viewBox="0 0 177 107" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch -->
     <desc>Created with Sketch.</desc>
     <defs></defs>
@@ -223,7 +223,7 @@
 </symbol>
 
 
-<symbol id="icon-plugins" width="179px" height="95px" viewBox="0 0 179 95" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-plugins" viewBox="0 0 179 95" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch -->
     <desc>Created with Sketch.</desc>
     <defs></defs>
@@ -324,7 +324,7 @@
 </symbol>
 
 
-<symbol id="icon-license" width="168px" height="104px" viewBox="0 0 168 104" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-license" viewBox="0 0 168 104" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <path d="M159.557,102.076 L159.557,23.847 C159.557,21.722 157.834,20 155.71,20 L98.847,20 C96.722,20 95,21.722 95,23.847 L95,102.077 L159.557,102.076" id="Fill-16" fill="#ADDDF8"></path>
@@ -417,7 +417,7 @@
 </symbol>
 
 
-<symbol id="icon-content" width="175px" height="110px" viewBox="0 0 175 110" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-content" viewBox="0 0 175 110" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Group-2" transform="translate(55.000000, 43.000000)">
@@ -540,7 +540,7 @@
 </symbol>
 
 
-<symbol id="icon-child" width="199px" height="100px" viewBox="0 0 199 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<symbol id="icon-child" viewBox="0 0 199 100" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <path d="M162.238416,41.0256956 L161.782416,38.7086956 C161.569416,37.0636956 160.061416,35.9026956 158.416416,36.1156956 L123.618416,40.6336956 C121.972416,40.8476956 120.811416,42.3546956 121.025416,43.9996956 L127.394416,93.0586956 L166.852416,80.9746956 L162.238416,41.0256956" id="Fill-261" fill="#FFFFFF"></path>


### PR DESCRIPTION
See the issue for details.
Tested in Chrome and Safari on Mac only.