### PR TITLE
Fix license activation for formatted license types

### DIFF
--- a/class-merlin.php
+++ b/class-merlin.php
@@ -7,7 +7,7 @@
  * Envato WordPress Theme Setup Wizard by David Baker.
  *
  * @package   Merlin WP
- * @version   @@pkg.version
+ * @version   1.0.0
  * @link      https://merlinwp.com/
  * @author    Rich Tabor, from ThemeBeans.com & the team at ProteusThemes.com
  * @copyright Copyright (c) 2018, Merlin WP of Inventionn LLC
@@ -222,7 +222,7 @@ class Merlin {
 	private function version() {
 
 		if ( ! defined( 'MERLIN_VERSION' ) ) {
-			define( 'MERLIN_VERSION', '@@pkg.version' );
+			define( 'MERLIN_VERSION', '1.0.0' );
 		}
 	}
 
@@ -450,7 +450,7 @@ class Merlin {
 		wp_enqueue_script( 'merlin', trailingslashit( $this->base_url ) . $this->directory . '/assets/js/merlin' . $suffix . '.js', array( 'jquery-core' ), MERLIN_VERSION );
 
 		$texts = array(
-			'something_went_wrong' => esc_html__( 'Something went wrong. Please refresh the page and try again!', '@@textdomain' ),
+			'something_went_wrong' => esc_html__( 'Something went wrong. Please refresh the page and try again!', 'merlin-wp' ),
 		);
 
 		// Localize the javascript.
@@ -596,12 +596,12 @@ class Merlin {
 
 		// Make sure $args are an array.
 		if ( empty( $args ) ) {
-			return __( 'Please define default parameters in the form of an array.', '@@textdomain' );
+			return __( 'Please define default parameters in the form of an array.', 'merlin-wp' );
 		}
 
 		// Define an icon.
 		if ( false === array_key_exists( 'icon', $args ) ) {
-			return __( 'Please define an SVG icon filename.', '@@textdomain' );
+			return __( 'Please define an SVG icon filename.', 'merlin-wp' );
 		}
 
 		// Set defaults.
@@ -710,20 +710,20 @@ class Merlin {
 
 		$this->steps = array(
 			'welcome' => array(
-				'name'    => esc_html__( 'Welcome', '@@textdomain' ),
+				'name'    => esc_html__( 'Welcome', 'merlin-wp' ),
 				'view'    => array( $this, 'welcome' ),
 				'handler' => array( $this, 'welcome_handler' ),
 			),
 		);
 
 		$this->steps['child'] = array(
-			'name' => esc_html__( 'Child', '@@textdomain' ),
+			'name' => esc_html__( 'Child', 'merlin-wp' ),
 			'view' => array( $this, 'child' ),
 		);
 
 		if ( $this->license_step_enabled ) {
 			$this->steps['license'] = array(
-				'name' => esc_html__( 'License', '@@textdomain' ),
+				'name' => esc_html__( 'License', 'merlin-wp' ),
 				'view' => array( $this, 'license' ),
 			);
 		}
@@ -731,7 +731,7 @@ class Merlin {
 		// Show the plugin importer, only if TGMPA is included.
 		if ( class_exists( 'TGM_Plugin_Activation' ) ) {
 			$this->steps['plugins'] = array(
-				'name' => esc_html__( 'Plugins', '@@textdomain' ),
+				'name' => esc_html__( 'Plugins', 'merlin-wp' ),
 				'view' => array( $this, 'plugins' ),
 			);
 		}
@@ -739,13 +739,13 @@ class Merlin {
 		// Show the content importer, only if there's demo content added.
 		if ( ! empty( $this->import_files ) ) {
 			$this->steps['content'] = array(
-				'name' => esc_html__( 'Content', '@@textdomain' ),
+				'name' => esc_html__( 'Content', 'merlin-wp' ),
 				'view' => array( $this, 'content' ),
 			);
 		}
 
 		$this->steps['ready'] = array(
-			'name' => esc_html__( 'Ready', '@@textdomain' ),
+			'name' => esc_html__( 'Ready', 'merlin-wp' ),
 			'view' => array( $this, 'ready' ),
 		);
 
@@ -850,7 +850,7 @@ class Merlin {
 		</footer>
 
 	<?php
-		$this->logger->debug( __( 'The welcome step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The welcome step has been displayed', 'merlin-wp' ) );
 	}
 
 	/**
@@ -944,7 +944,7 @@ class Merlin {
 			<?php wp_nonce_field( 'merlin' ); ?>
 		</footer>
 		<?php
-		$this->logger->debug( __( 'The license activation step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The license activation step has been displayed', 'merlin-wp' ) );
 	}
 
 
@@ -1014,7 +1014,7 @@ class Merlin {
 			<?php wp_nonce_field( 'merlin' ); ?>
 		</footer>
 	<?php
-		$this->logger->debug( __( 'The child theme installation step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The child theme installation step has been displayed', 'merlin-wp' ) );
 	}
 
 	/**
@@ -1101,8 +1101,8 @@ class Merlin {
 								<span><?php echo esc_html( $plugin['name'] ); ?></span>
 
 								<span class="badge">
-									<span class="hint--top" aria-label="<?php esc_html_e( 'Required', '@@textdomain' ); ?>">
-										<?php esc_html_e( 'req', '@@textdomain' ); ?>
+									<span class="hint--top" aria-label="<?php esc_html_e( 'Required', 'merlin-wp' ); ?>">
+										<?php esc_html_e( 'req', 'merlin-wp' ); ?>
 									</span>
 								</span>
 							</label>
@@ -1142,7 +1142,7 @@ class Merlin {
 		</form>
 
 	<?php
-		$this->logger->debug( __( 'The plugin installation step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The plugin installation step has been displayed', 'merlin-wp' ) );
 	}
 
 	/**
@@ -1188,7 +1188,7 @@ class Merlin {
 					</select>
 
 					<div class="merlin__select-control-help">
-						<span class="hint--top" aria-label="<?php echo esc_attr__( 'Select Demo', '@@textdomain' ); ?>">
+						<span class="hint--top" aria-label="<?php echo esc_attr__( 'Select Demo', 'merlin-wp' ); ?>">
 							<?php echo wp_kses( $this->svg( array( 'icon' => 'downarrow' ) ), $this->svg_allowed_html() ); ?>
 						</span>
 					</div>
@@ -1226,7 +1226,7 @@ class Merlin {
 		</form>
 
 	<?php
-		$this->logger->debug( __( 'The content import step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The content import step has been displayed', 'merlin-wp' ) );
 	}
 
 
@@ -1306,7 +1306,7 @@ class Merlin {
 		</footer>
 
 	<?php
-		$this->logger->debug( __( 'The final step has been displayed', '@@textdomain' ) );
+		$this->logger->debug( __( 'The final step has been displayed', 'merlin-wp' ) );
 	}
 
 	/**
@@ -1383,7 +1383,7 @@ class Merlin {
 				switch_theme( $slug );
 			endif;
 
-			$this->logger->debug( __( 'The existing child theme was activated', '@@textdomain' ) );
+			$this->logger->debug( __( 'The existing child theme was activated', 'merlin-wp' ) );
 
 			wp_send_json(
 				array(
@@ -1400,7 +1400,7 @@ class Merlin {
 			switch_theme( $slug );
 		endif;
 
-		$this->logger->debug( __( 'The newly generated child theme was activated', '@@textdomain' ) );
+		$this->logger->debug( __( 'The newly generated child theme was activated', 'merlin-wp' ) );
 
 		wp_send_json(
 			array(
@@ -1421,7 +1421,7 @@ class Merlin {
 			wp_send_json(
 				array(
 					'success' => false,
-					'message' => esc_html__( 'Yikes! The theme activation failed. Please try again or contact support.', '@@textdomain' ),
+					'message' => esc_html__( 'Yikes! The theme activation failed. Please try again or contact support.', 'merlin-wp' ),
 				)
 			);
 		}
@@ -1430,12 +1430,12 @@ class Merlin {
 			wp_send_json(
 				array(
 					'success' => false,
-					'message' => esc_html__( 'Please add your license key before attempting to activate one.', '@@textdomain' ),
+					'message' => esc_html__( 'Please add your license key before attempting to activate one.', 'merlin-wp' ),
 				)
 			);
 		}
 
-		$license_key = sanitize_key( $_POST['license_key'] );
+		$license_key = sanitize_text_field( $_POST['license_key'] );
 
 		if ( ! has_filter( 'merlin_ajax_activate_license' ) ) {
 			$result = $this->edd_activate_license( $license_key );
@@ -1443,7 +1443,7 @@ class Merlin {
 			$result = apply_filters( 'merlin_ajax_activate_license', $license_key );
 		}
 
-		$this->logger->debug( __( 'The license activation was performed with the following results', '@@textdomain' ), $result );
+		$this->logger->debug( __( 'The license activation was performed with the following results', 'merlin-wp' ), $result );
 
 		wp_send_json( array_merge( array( 'done' => 1 ), $result ) );
 	}
@@ -1489,7 +1489,7 @@ class Merlin {
 			if ( is_wp_error( $response ) ) {
 				$message = $response->get_error_message();
 			} else {
-				$message = esc_html__( 'An error occurred, please try again.', '@@textdomain' );
+				$message = esc_html__( 'An error occurred, please try again.', 'merlin-wp' );
 			}
 		} else {
 
@@ -1502,35 +1502,35 @@ class Merlin {
 					case 'expired':
 						$message = sprintf(
 							/* translators: Expiration date */
-							esc_html__( 'Your license key expired on %s.', '@@textdomain' ),
+							esc_html__( 'Your license key expired on %s.', 'merlin-wp' ),
 							date_i18n( get_option( 'date_format' ), strtotime( $license_data->expires, current_time( 'timestamp' ) ) )
 						);
 						break;
 
 					case 'revoked':
-						$message = esc_html__( 'Your license key has been disabled.', '@@textdomain' );
+						$message = esc_html__( 'Your license key has been disabled.', 'merlin-wp' );
 						break;
 
 					case 'missing':
-						$message = esc_html__( 'This appears to be an invalid license key. Please try again or contact support.', '@@textdomain' );
+						$message = esc_html__( 'This appears to be an invalid license key. Please try again or contact support.', 'merlin-wp' );
 						break;
 
 					case 'invalid':
 					case 'site_inactive':
-						$message = esc_html__( 'Your license is not active for this URL.', '@@textdomain' );
+						$message = esc_html__( 'Your license is not active for this URL.', 'merlin-wp' );
 						break;
 
 					case 'item_name_mismatch':
 						/* translators: EDD Item Name */
-						$message = sprintf( esc_html__( 'This appears to be an invalid license key for %s.', '@@textdomain' ), $this->edd_item_name );
+						$message = sprintf( esc_html__( 'This appears to be an invalid license key for %s.', 'merlin-wp' ), $this->edd_item_name );
 						break;
 
 					case 'no_activations_left':
-						$message = esc_html__( 'Your license key has reached its activation limit.', '@@textdomain' );
+						$message = esc_html__( 'Your license key has reached its activation limit.', 'merlin-wp' );
 						break;
 
 					default:
-						$message = esc_html__( 'An error occurred, please try again.', '@@textdomain' );
+						$message = esc_html__( 'An error occurred, please try again.', 'merlin-wp' );
 						break;
 				}
 			} else {
@@ -1620,7 +1620,7 @@ class Merlin {
 		// Let's remove the tabs so that it displays nicely.
 		$output = trim( preg_replace( '/\t+/', '', $output ) );
 
-		$this->logger->debug( __( 'The child theme functions.php content was generated', '@@textdomain' ) );
+		$this->logger->debug( __( 'The child theme functions.php content was generated', 'merlin-wp' ) );
 
 		// Filterable return.
 		return apply_filters( 'merlin_generate_child_functions_php', $output, $slug );
@@ -1651,7 +1651,7 @@ class Merlin {
 		// Let's remove the tabs so that it displays nicely.
 		$output = trim( preg_replace( '/\t+/', '', $output ) );
 
-		$this->logger->debug( __( 'The child theme style.css content was generated', '@@textdomain' ) );
+		$this->logger->debug( __( 'The child theme style.css content was generated', 'merlin-wp' ) );
 
 		return apply_filters( 'merlin_generate_child_style_css', $output, $slug, $parent, $version );
 	}
@@ -1685,9 +1685,9 @@ class Merlin {
 		if ( ! empty( $screenshot ) && file_exists( $screenshot ) ) {
 			$copied = copy( $screenshot, $path . '/screenshot.' . $screenshot_ext );
 
-			$this->logger->debug( __( 'The child theme screenshot was copied to the child theme, with the following result', '@@textdomain' ), array( 'copied' => $copied ) );
+			$this->logger->debug( __( 'The child theme screenshot was copied to the child theme, with the following result', 'merlin-wp' ), array( 'copied' => $copied ) );
 		} else {
-			$this->logger->debug( __( 'The child theme screenshot was not generated, because of these results', '@@textdomain' ), array( 'screenshot' => $screenshot ) );
+			$this->logger->debug( __( 'The child theme screenshot was not generated, because of these results', 'merlin-wp' ), array( 'screenshot' => $screenshot ) );
 		}
 	}
 
@@ -1716,7 +1716,7 @@ class Merlin {
 					'_wpnonce'      => wp_create_nonce( 'bulk-plugins' ),
 					'action'        => 'tgmpa-bulk-activate',
 					'action2'       => - 1,
-					'message'       => esc_html__( 'Activating', '@@textdomain' ),
+					'message'       => esc_html__( 'Activating', 'merlin-wp' ),
 				);
 				break;
 			}
@@ -1732,7 +1732,7 @@ class Merlin {
 					'_wpnonce'      => wp_create_nonce( 'bulk-plugins' ),
 					'action'        => 'tgmpa-bulk-update',
 					'action2'       => - 1,
-					'message'       => esc_html__( 'Updating', '@@textdomain' ),
+					'message'       => esc_html__( 'Updating', 'merlin-wp' ),
 				);
 				break;
 			}
@@ -1748,7 +1748,7 @@ class Merlin {
 					'_wpnonce'      => wp_create_nonce( 'bulk-plugins' ),
 					'action'        => 'tgmpa-bulk-install',
 					'action2'       => - 1,
-					'message'       => esc_html__( 'Installing', '@@textdomain' ),
+					'message'       => esc_html__( 'Installing', 'merlin-wp' ),
 				);
 				break;
 			}
@@ -1756,7 +1756,7 @@ class Merlin {
 
 		if ( $json ) {
 			$this->logger->debug(
-				__( 'A plugin with the following data will be processed', '@@textdomain' ),
+				__( 'A plugin with the following data will be processed', 'merlin-wp' ),
 				array(
 					'plugin_slug' => $_POST['slug'],
 					'message'     => $json['message'],
@@ -1764,11 +1764,11 @@ class Merlin {
 			);
 
 			$json['hash']    = md5( serialize( $json ) );
-			$json['message'] = esc_html__( 'Installing', '@@textdomain' );
+			$json['message'] = esc_html__( 'Installing', 'merlin-wp' );
 			wp_send_json( $json );
 		} else {
 			$this->logger->debug(
-				__( 'A plugin with the following data was processed', '@@textdomain' ),
+				__( 'A plugin with the following data was processed', 'merlin-wp' ),
 				array(
 					'plugin_slug' => $_POST['slug'],
 				)
@@ -1777,7 +1777,7 @@ class Merlin {
 			wp_send_json(
 				array(
 					'done'    => 1,
-					'message' => esc_html__( 'Success', '@@textdomain' ),
+					'message' => esc_html__( 'Success', 'merlin-wp' ),
 				)
 			);
 		}
@@ -1800,12 +1800,12 @@ class Merlin {
 		}
 
 		if ( ! check_ajax_referer( 'merlin_nonce', 'wpnonce' ) || empty( $_POST['content'] ) && isset( $content[ $_POST['content'] ] ) ) {
-			$this->logger->error( __( 'The content importer AJAX call failed to start, because of incorrect data', '@@textdomain' ) );
+			$this->logger->error( __( 'The content importer AJAX call failed to start, because of incorrect data', 'merlin-wp' ) );
 
 			wp_send_json_error(
 				array(
 					'error'   => 1,
-					'message' => esc_html__( 'Invalid content!', '@@textdomain' ),
+					'message' => esc_html__( 'Invalid content!', 'merlin-wp' ),
 				)
 			);
 		}
@@ -1816,7 +1816,7 @@ class Merlin {
 		if ( isset( $_POST['proceed'] ) ) {
 			if ( is_callable( $this_content['install_callback'] ) ) {
 				$this->logger->info(
-					__( 'The content import AJAX call will be executed with this import data', '@@textdomain' ),
+					__( 'The content import AJAX call will be executed with this import data', 'merlin-wp' ),
 					array(
 						'title' => $this_content['title'],
 						'data'  => $this_content['data'],
@@ -1858,7 +1858,7 @@ class Merlin {
 			wp_send_json( $json );
 		} else {
 			$this->logger->error(
-				__( 'The content import AJAX call failed with this passed data', '@@textdomain' ),
+				__( 'The content import AJAX call failed with this passed data', 'merlin-wp' ),
 				array(
 					'selected_content_index' => $selected_import,
 					'importing_content'      => $_POST['content'],
@@ -1869,7 +1869,7 @@ class Merlin {
 			wp_send_json(
 				array(
 					'error'   => 1,
-					'message' => esc_html__( 'Error', '@@textdomain' ),
+					'message' => esc_html__( 'Error', 'merlin-wp' ),
 					'logs'    => '',
 					'errors'  => '',
 				)
@@ -1883,12 +1883,12 @@ class Merlin {
 	 */
 	public function _ajax_get_total_content_import_items() {
 		if ( ! check_ajax_referer( 'merlin_nonce', 'wpnonce' ) && empty( $_POST['selected_index'] ) ) {
-			$this->logger->error( __( 'The content importer AJAX call for retrieving total content import items failed to start, because of incorrect data.', '@@textdomain' ) );
+			$this->logger->error( __( 'The content importer AJAX call for retrieving total content import items failed to start, because of incorrect data.', 'merlin-wp' ) );
 
 			wp_send_json_error(
 				array(
 					'error'   => 1,
-					'message' => esc_html__( 'Invalid data!', '@@textdomain' ),
+					'message' => esc_html__( 'Invalid data!', 'merlin-wp' ),
 				)
 			);
 		}
@@ -1979,11 +1979,11 @@ class Merlin {
 
 		if ( ! empty( $import_files['content'] ) ) {
 			$content['content'] = array(
-				'title'            => esc_html__( 'Content', '@@textdomain' ),
-				'description'      => esc_html__( 'Demo content data.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'Content', 'merlin-wp' ),
+				'description'      => esc_html__( 'Demo content data.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'install_callback' => array( $this->importer, 'import' ),
 				'data'             => $import_files['content'],
@@ -1992,11 +1992,11 @@ class Merlin {
 
 		if ( ! empty( $import_files['widgets'] ) ) {
 			$content['widgets'] = array(
-				'title'            => esc_html__( 'Widgets', '@@textdomain' ),
-				'description'      => esc_html__( 'Sample widgets data.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'Widgets', 'merlin-wp' ),
+				'description'      => esc_html__( 'Sample widgets data.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'install_callback' => array( 'Merlin_Widget_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $import_files['widgets'],
@@ -2005,11 +2005,11 @@ class Merlin {
 
 		if ( ! empty( $import_files['sliders'] ) ) {
 			$content['sliders'] = array(
-				'title'            => esc_html__( 'Revolution Slider', '@@textdomain' ),
-				'description'      => esc_html__( 'Sample Revolution sliders data.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'Revolution Slider', 'merlin-wp' ),
+				'description'      => esc_html__( 'Sample Revolution sliders data.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'install_callback' => array( $this, 'import_revolution_sliders' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $import_files['sliders'],
@@ -2018,11 +2018,11 @@ class Merlin {
 
 		if ( ! empty( $import_files['options'] ) ) {
 			$content['options'] = array(
-				'title'            => esc_html__( 'Options', '@@textdomain' ),
-				'description'      => esc_html__( 'Sample theme options data.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'Options', 'merlin-wp' ),
+				'description'      => esc_html__( 'Sample theme options data.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'install_callback' => array( 'Merlin_Customizer_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $import_files['options'],
@@ -2031,11 +2031,11 @@ class Merlin {
 
 		if ( ! empty( $import_files['redux'] ) ) {
 			$content['redux'] = array(
-				'title'            => esc_html__( 'Redux Options', '@@textdomain' ),
-				'description'      => esc_html__( 'Redux framework options.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'Redux Options', 'merlin-wp' ),
+				'description'      => esc_html__( 'Redux framework options.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'install_callback' => array( 'Merlin_Redux_Importer', 'import' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $import_files['redux'],
@@ -2044,11 +2044,11 @@ class Merlin {
 
 		if ( false !== has_action( 'merlin_after_all_import' ) ) {
 			$content['after_import'] = array(
-				'title'            => esc_html__( 'After import setup', '@@textdomain' ),
-				'description'      => esc_html__( 'After import setup.', '@@textdomain' ),
-				'pending'          => esc_html__( 'Pending', '@@textdomain' ),
-				'installing'       => esc_html__( 'Installing', '@@textdomain' ),
-				'success'          => esc_html__( 'Success', '@@textdomain' ),
+				'title'            => esc_html__( 'After import setup', 'merlin-wp' ),
+				'description'      => esc_html__( 'After import setup.', 'merlin-wp' ),
+				'pending'          => esc_html__( 'Pending', 'merlin-wp' ),
+				'installing'       => esc_html__( 'Installing', 'merlin-wp' ),
+				'success'          => esc_html__( 'Success', 'merlin-wp' ),
 				'install_callback' => array( $this->hooks, 'after_all_import_action' ),
 				'checked'          => $this->is_possible_upgrade() ? 0 : 1,
 				'data'             => $selected_import_index,
@@ -2074,7 +2074,7 @@ class Merlin {
 
 		$response = $importer->importSliderFromPost( true, true, $file );
 
-		$this->logger->info( __( 'The revolution slider import was executed', '@@textdomain' ) );
+		$this->logger->info( __( 'The revolution slider import was executed', 'merlin-wp' ) );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return 'true';
@@ -2090,7 +2090,7 @@ class Merlin {
 	 */
 	public function pt_importer_new_ajax_request_response_data( $data ) {
 		$data['url']      = admin_url( 'admin-ajax.php' );
-		$data['message']  = esc_html__( 'Installing', '@@textdomain' );
+		$data['message']  = esc_html__( 'Installing', 'merlin-wp' );
 		$data['proceed']  = 'true';
 		$data['action']   = 'merlin_content';
 		$data['content']  = 'content';
@@ -2111,7 +2111,7 @@ class Merlin {
 			update_option( 'page_on_front', $homepage->ID );
 			update_option( 'show_on_front', 'page' );
 
-			$this->logger->debug( __( 'The home page was set', '@@textdomain' ), array( 'homepage_id' => $homepage ) );
+			$this->logger->debug( __( 'The home page was set', 'merlin-wp' ), array( 'homepage_id' => $homepage ) );
 		}
 
 		// Set static blog page.
@@ -2121,7 +2121,7 @@ class Merlin {
 			update_option( 'page_for_posts', $blogpage->ID );
 			update_option( 'show_on_front', 'page' );
 
-			$this->logger->debug( __( 'The blog page was set', '@@textdomain' ), array( 'blog_page_id' => $blogpage ) );
+			$this->logger->debug( __( 'The blog page was set', 'merlin-wp' ), array( 'blog_page_id' => $blogpage ) );
 		}
 	}
 
@@ -2136,7 +2136,7 @@ class Merlin {
 			$hello_world->post_status = 'draft';
 			wp_update_post( $hello_world );
 
-			$this->logger->debug( __( 'The Hello world post status was set to draft', '@@textdomain' ) );
+			$this->logger->debug( __( 'The Hello world post status was set to draft', 'merlin-wp' ) );
 		}
 	}
 
@@ -2160,7 +2160,7 @@ class Merlin {
 			if ( ! empty( $import_file['import_file_name'] ) ) {
 				$filtered_import_file_info[] = $import_file;
 			} else {
-				$this->logger->warning( __( 'This predefined demo import does not have the name parameter: import_file_name', '@@textdomain' ), $import_file );
+				$this->logger->warning( __( 'This predefined demo import does not have the name parameter: import_file_name', 'merlin-wp' ), $import_file );
 			}
 		}
 


### PR DESCRIPTION
EDD  supports make your own license format. For example default format is looks like "s5Lds8pMnd8pJdiOm82Kh5OOIy" but if you create your own format like this "8915-8486-5648-9458-9878" you will get 'An error occurred, please try again.' error. Because sanitize_key function removes "-" symbol. So i used sanitize_text_field instead of sanitize_key function.